### PR TITLE
fix: import SCSS theme files

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,7 +2,7 @@
 
 @import "./app/shared/custom";
 @import '~bootstrap/scss/bootstrap';
-@import '~@progress/kendo-theme-bootstrap/dist/all';
+@import '~@progress/kendo-theme-bootstrap/scss/all';
 @import './app/dashboard.style';
 
 body {


### PR DESCRIPTION
Importing CSS files is deprecated. 